### PR TITLE
Update BaselineOfGitlabHeatMap.class.st

### DIFF
--- a/BaselineOfGitlabHeatMap/BaselineOfGitlabHeatMap.class.st
+++ b/BaselineOfGitlabHeatMap/BaselineOfGitlabHeatMap.class.st
@@ -20,7 +20,7 @@ BaselineOfGitlabHeatMap >> defineDependencies: spec [
 		
 	spec
     baseline: 'GitLabHealth'
-    with: [ spec repository: 'github://moosetechnology/GitProjectHealth:main/src' ]
+    with: [ spec repository: 'github://moosetechnology/GitProjectHealth:1.x.x/src' ]
 ]
 
 { #category : 'baselines' }

--- a/BaselineOfGitlabHeatMap/BaselineOfGitlabHeatMap.class.st
+++ b/BaselineOfGitlabHeatMap/BaselineOfGitlabHeatMap.class.st
@@ -20,7 +20,7 @@ BaselineOfGitlabHeatMap >> defineDependencies: spec [
 		
 	spec
     baseline: 'GitLabHealth'
-    with: [ spec repository: 'github://moosetechnology/GitProjectHealth:v1.3.2/src' ]
+    with: [ spec repository: 'github://moosetechnology/GitProjectHealth:v1.x.x/src' ]
 ]
 
 { #category : 'baselines' }

--- a/BaselineOfGitlabHeatMap/BaselineOfGitlabHeatMap.class.st
+++ b/BaselineOfGitlabHeatMap/BaselineOfGitlabHeatMap.class.st
@@ -20,7 +20,7 @@ BaselineOfGitlabHeatMap >> defineDependencies: spec [
 		
 	spec
     baseline: 'GitLabHealth'
-    with: [ spec repository: 'github://moosetechnology/GitProjectHealth:v1.x.x/src' ]
+    with: [ spec repository: 'github://moosetechnology/GitProjectHealth:1.3.2/src' ]
 ]
 
 { #category : 'baselines' }

--- a/BaselineOfGitlabHeatMap/BaselineOfGitlabHeatMap.class.st
+++ b/BaselineOfGitlabHeatMap/BaselineOfGitlabHeatMap.class.st
@@ -20,7 +20,7 @@ BaselineOfGitlabHeatMap >> defineDependencies: spec [
 		
 	spec
     baseline: 'GitLabHealth'
-    with: [ spec repository: 'github://moosetechnology/GitProjectHealth:1.x.x/src' ]
+    with: [ spec repository: 'github://moosetechnology/GitProjectHealth:v1.3.2/src' ]
 ]
 
 { #category : 'baselines' }


### PR DESCRIPTION
lock gitprojecthealth version to 1.x.x

Since v2 of gitprojecthealth introduces API changes, older project should be version lock to v1 